### PR TITLE
Dragonchess implementation

### DIFF
--- a/backend/api/auth.py
+++ b/backend/api/auth.py
@@ -58,6 +58,14 @@ TOURMASTER_ISS = os.getenv("TOURMASTER_JWT_ISS", "main-portal")
 TOURMASTER_TOKEN_EXPIRE_SECONDS = int(os.getenv("TOURMASTER_TOKEN_EXPIRE_SECONDS", "300"))
 
 
+# DragonChess 专用配置
+DRAGONCHESS_SECRET = os.getenv("DRAGONCHESS_JWT_SECRET", "change-this-dragonchess-secret")
+DRAGONCHESS_ALG = os.getenv("DRAGONCHESS_JWT_ALG", "HS256")
+DRAGONCHESS_AUD = os.getenv("DRAGONCHESS_JWT_AUD", "dragonchess")
+DRAGONCHESS_ISS = os.getenv("DRAGONCHESS_JWT_ISS", "main-portal")
+DRAGONCHESS_TOKEN_EXPIRE_SECONDS = int(os.getenv("DRAGONCHESS_TOKEN_EXPIRE_SECONDS", "300"))
+
+
 # 密码加密
 pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
 
@@ -167,6 +175,24 @@ def create_tourmaster_token(claims: Dict[str, Any], expires_seconds: Optional[in
     })
 
     return jwt.encode(to_encode, TOURMASTER_SECRET, algorithm=TOURMASTER_ALG)
+
+
+
+def create_dragonchess_token(claims: Dict[str, Any], expires_seconds: Optional[int] = None) -> str:
+    """
+    创建 DragonChess 短期访问令牌
+    """
+    to_encode = claims.copy()
+    expire_sec = expires_seconds or DRAGONCHESS_TOKEN_EXPIRE_SECONDS
+    expire = datetime.utcnow() + timedelta(seconds=expire_sec)
+
+    to_encode.update({
+        "exp": expire,
+        "iss": DRAGONCHESS_ISS,
+        "aud": DRAGONCHESS_AUD,
+    })
+
+    return jwt.encode(to_encode, DRAGONCHESS_SECRET, algorithm=DRAGONCHESS_ALG)
 
 
 def authenticate_user(db: Session, username: str, password: str) -> Optional[User]:

--- a/backend/api/routes/games.py
+++ b/backend/api/routes/games.py
@@ -23,6 +23,9 @@ from auth import (
   
     create_tourmaster_token,
     TOURMASTER_TOKEN_EXPIRE_SECONDS,
+
+    create_dragonchess_token,
+    DRAGONCHESS_TOKEN_EXPIRE_SECONDS,
 )
 
 
@@ -197,6 +200,36 @@ async def issue_tourmaster_token(
         data={
             "game_token": token,
             "expires_in": TOURMASTER_TOKEN_EXPIRE_SECONDS,
+            "user": {
+                "id": current_user.id,
+                "username": current_user.username,
+            },
+        },
+    )
+
+
+@router.post("/dragonchess/token", response_model=APIResponse)
+async def issue_dragonchess_token(
+    current_user: User = Depends(get_current_active_user),
+    db: Session = Depends(get_db),
+):
+    """
+    为当前登录用户签发 DragonChess 短期令牌
+    """
+    claims = {
+        "sub": current_user.username,
+        "user_id": current_user.id,
+        "username": current_user.username,
+    }
+
+    token = create_dragonchess_token(claims)
+
+    return APIResponse(
+        success=True,
+        message="ok",
+        data={
+            "game_token": token,
+            "expires_in": DRAGONCHESS_TOKEN_EXPIRE_SECONDS,
             "user": {
                 "id": current_user.id,
                 "username": current_user.username,

--- a/frontend/main_page/app/[locale]/home/page.tsx
+++ b/frontend/main_page/app/[locale]/home/page.tsx
@@ -19,6 +19,7 @@ export default function HomePage() {
     handleQuantumGo,
     handleChessMater,
     handleChessTourmaster,
+    handleDragonChess,
   } = useGameLauncher();
 
   if (loading) {
@@ -38,6 +39,7 @@ export default function HomePage() {
       onQuantumGo={handleQuantumGo}
       onChessMater={handleChessMater}
       onChessTourmaster={handleChessTourmaster}
+      onDragonChess={handleDragonChess}
       onLogout={logout}
     />
   );

--- a/frontend/main_page/app/[locale]/page.tsx
+++ b/frontend/main_page/app/[locale]/page.tsx
@@ -107,6 +107,16 @@ export default function Home() {
       linkUrl: `/${locale}/login`,
     },
     {
+      key: "dragonChess",
+      image: "/images/game-dragon-chess.jpg",
+      hoverImage: "/images/6.jpg", // or another hover image
+      buttonColor: "bg-[#D14B4B]",
+      titleColor: "text-gray-800",
+      taglineColor: "text-[#D14B4B]",
+      descriptionColor: "text-gray-600",
+      linkUrl: `/${locale}/login`,
+    },
+    {
       key: "more",
       image: "/images/more.jpg",
       hoverImage: "/images/6.jpg",

--- a/frontend/main_page/components/home/HomeContent.tsx
+++ b/frontend/main_page/components/home/HomeContent.tsx
@@ -11,6 +11,7 @@ interface HomeContentProps {
   onQuantumGo: () => void;
   onChessMater: () => void;
   onChessTourmaster: () => void;
+  onDragonChess: () => void;
   onLogout: () => void;
 }
 
@@ -26,6 +27,7 @@ export default function HomeContent({
   onQuantumGo,
   onChessMater,
   onChessTourmaster,
+  onDragonChess,
   onLogout,
 }: HomeContentProps) {
   const tCommon = useTranslations("common");
@@ -74,6 +76,13 @@ export default function HomeContent({
       onClick: onChessTourmaster,
       color: "bg-[#A3BE8C]",
       hoverColor: "hover:bg-[#93AE7C]",
+    },
+    {
+      key: "dragonChess",
+      name: tHome("dragonChess"),
+      onClick: onDragonChess,
+      color: "bg-[#D14B4B]",
+      hoverColor: "hover:bg-[#B93F3F]",
     },
   ];
 

--- a/frontend/main_page/hooks/useGameLauncher.ts
+++ b/frontend/main_page/hooks/useGameLauncher.ts
@@ -130,6 +130,15 @@ export function useGameLauncher() {
     window.open("https://sudoku.deepbraintechnology.com/", "_blank");
   };
 
+  const handleDragonChess = () => {
+    launchGame({
+      gameKey: "dragonChess",
+      apiEndpoint: "/api/games/dragonchess/token",
+      gameUrl: "https://dragonchess.pages.dev/",
+      openInNewTab: false,
+    });
+  };
+
   return {
     handleFogChess,
     handleSudokuBattle,
@@ -137,6 +146,7 @@ export function useGameLauncher() {
     handleQuantumGo,
     handleChessMater,
     handleChessTourmaster,
+    handleDragonChess,
   };
 }
 

--- a/frontend/main_page/language/en.json
+++ b/frontend/main_page/language/en.json
@@ -26,6 +26,7 @@
     "quantumGo": "Quantum Go",
     "chessMater": "ChessMater",
     "chessTourmaster": "Chess Tourmaster",
+    "dragonChess": "Dragon Chess",
     "failedToStartGame": "Failed to start game"
   },
   "login": {
@@ -107,6 +108,11 @@
         "name": "Chess Tourmaster",
         "tagline": "Strategic Chess Adventures Across Dynamic Boards.",
         "description": "Challenge your tactical planning and adaptability with innovative chess-based puzzles set across evolving board designs."
+      },
+      "dragonChess": {
+        "name": "Dragon Chess",
+        "tagline": "Command Dragons. Master the Board.",
+        "description": "A strategic chess variant infused with dragon powers, elemental abilities, and dynamic board mechanics."
       },
       "more": {
         "name": "More Games",

--- a/frontend/main_page/language/zh.json
+++ b/frontend/main_page/language/zh.json
@@ -26,6 +26,7 @@
     "quantumGo": "量子围棋",
     "chessMater": "棋艺大师",
     "chessTourmaster": "棋境之旅",
+    "dragonChess": "龙棋",
     "failedToStartGame": "启动游戏失败"
   },
   "login": {
@@ -107,6 +108,11 @@
         "name": "棋旅大师",
         "tagline": "多维棋盘探索，策略思维升级。",
         "description": "在不断变化的棋盘与路径中制定最佳行动方案，挑战你的全局规划、适应力与高阶决策能力。"
+      },
+      "dragonChess": {
+        "name": "龙棋",
+        "tagline": "驭龙而战，智胜棋局",
+        "description": "融合经典象棋策略与龙之能力机制，通过特殊棋子与动态规则变化，考验你的全局规划、策略适应力与创造性决策能力。"
       },
       "more": {
         "name": "更多游戏",


### PR DESCRIPTION
Add DragonChess to the homepage with full launch and localization support.
Includes backend support for issuing game tokens, frontend launch handling, and UI updates.
Also adds English and Chinese translations and homepage image assets.